### PR TITLE
Parsing failure when the class file size is too large

### DIFF
--- a/src/main/java/com/github/zxh/classpy/helper/UrlHelper.java
+++ b/src/main/java/com/github/zxh/classpy/helper/UrlHelper.java
@@ -9,7 +9,10 @@ public class UrlHelper {
     public static byte[] readData(URL url) throws IOException {
         try (InputStream is = url.openStream()) {
             byte[] data = new byte[is.available()];
-            is.read(data);
+            int len = 0;
+            while (len < data.length){
+                len += is.read(data, len, data.length - len);
+            }
             return data;
         }
     }


### PR DESCRIPTION
In my Mac(JDK 1.8.0_40), `InputStream.read(byte[])` read 8192 bytes at most. When the class file size is greater than 8192 bytes, it will get parsing failure.