### PR TITLE
Can't read jar file when there are spaces in path

### DIFF
--- a/src/main/java/com/github/zxh/classpy/gui/jar/JarTreeLoader.java
+++ b/src/main/java/com/github/zxh/classpy/gui/jar/JarTreeLoader.java
@@ -11,8 +11,7 @@ import java.util.HashMap;
 public class JarTreeLoader {
 
     public static JarTreeNode load(File jarFile) throws Exception {
-        URI jarUri = new URI("jar", jarFile.toPath().toUri().toString(), null);
-        try (FileSystem zipFs = FileSystems.newFileSystem(jarUri, new HashMap<>())) {
+        try (FileSystem zipFs = FileSystems.newFileSystem(jarFile.toPath(), null)) {
             return path2node(zipFs.getPath("/"));
         }
     }


### PR DESCRIPTION
当读取的jar包的路径中包含空格时，会读取失败
```
loading file:/C:/Program%20Files/Java/jre1.8.0_121/lib/rt.jar...
java.nio.file.FileSystemNotFoundException: C:\Program%20Files\Java\jre1.8.0_121\lib\rt.jar
	at com.sun.nio.zipfs.ZipFileSystem.<init>(ZipFileSystem.java:120)
	at com.sun.nio.zipfs.ZipFileSystemProvider.newFileSystem(ZipFileSystemProvider.java:117)
	at java.nio.file.FileSystems.newFileSystem(FileSystems.java:326)
	at java.nio.file.FileSystems.newFileSystem(FileSystems.java:276)
	at com.github.zxh.classpy.gui.jar.JarTreeLoader.load(JarTreeLoader.java:15)
```

改动后可以读取了，不确定是否是个bug，以下是java版本

```shell
$ java -version
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
```