### PR TITLE
[fix bug] use '((long) high_bytes << 32) + low_bytes' to calculate bits

### DIFF
--- a/classpy-classfile/src/main/java/com/github/zxh/classpy/classfile/constant/ConstantDoubleInfo.java
+++ b/classpy-classfile/src/main/java/com/github/zxh/classpy/classfile/constant/ConstantDoubleInfo.java
@@ -18,7 +18,7 @@ public class ConstantDoubleInfo extends ConstantInfo {
     protected String loadDesc(ConstantPool cp) {
         long high = super.getUInt("high_bytes");
         long low = super.getUInt("low_bytes") & 0xffffffffL;
-        double d = Double.longBitsToDouble(high << 32 | low);
+        double d = Double.longBitsToDouble((high << 32) + low);
         return String.valueOf(d);
     }
     

--- a/classpy-classfile/src/main/java/com/github/zxh/classpy/classfile/constant/ConstantLongInfo.java
+++ b/classpy-classfile/src/main/java/com/github/zxh/classpy/classfile/constant/ConstantLongInfo.java
@@ -18,7 +18,7 @@ public class ConstantLongInfo extends ConstantInfo {
     protected String loadDesc(ConstantPool cp) {
         long high = super.getUInt("high_bytes");
         long low = super.getUInt("low_bytes") & 0xffffffffL;
-        long l = high << 32 | low;
+        long l = (high << 32) + low;
         return String.valueOf(l);
     }
     


### PR DESCRIPTION
According to[ jvmS8 4.4.5. The CONSTANT_Long_info and CONSTANT_Double_info Structures](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.5)

We need to use '**((long) high_bytes << 32) + low_bytes**' to calculate 'bits'.

But for right now, the project is using '**((long) high_bytes << 32) | low_bytes**':

`ConstantLongInfo.java`:

```java
    @Override
    protected String loadDesc(ConstantPool cp) {
        long high = super.getUInt("high_bytes");
        long low = super.getUInt("low_bytes") & 0xffffffffL;
        long l = (high << 32) + low;
        return String.valueOf(l);
    }
```

`ConstantDoubleInfo.java`:

```java
    @Override
    protected String loadDesc(ConstantPool cp) {
        long high = super.getUInt("high_bytes");
        long low = super.getUInt("low_bytes") & 0xffffffffL;
        double d = Double.longBitsToDouble((high << 32) + low);
        return String.valueOf(d);
    }
```