### PR TITLE
修复打开 module-info.class 失败的问题

### DIFF
--- a/classpy-classfile/src/main/java/com/github/zxh/classpy/classfile/attribute/ModuleAttribute.java
+++ b/classpy-classfile/src/main/java/com/github/zxh/classpy/classfile/attribute/ModuleAttribute.java
@@ -73,8 +73,13 @@ public class ModuleAttribute extends AttributeInfo {
         @Override
         protected void postRead(ConstantPool cp) {
             String moduleName = cp.getConstantDesc(super.getUInt("requires_index"));
-            String version = cp.getConstantDesc(super.getUInt("requires_version_index"));
-            setDesc(moduleName + "@" + version);
+            int idx = super.getUInt("requires_version_index");
+            if (idx == 0) {
+                setDesc(moduleName);
+            } else {
+                String version = cp.getConstantDesc(idx);
+                setDesc(moduleName + "@" + version);
+            }
         }
 
     }


### PR DESCRIPTION
根据 [jvms §4.7.25](https://docs.oracle.com/javase/specs/jvms/se13/html/jvms-4.html#jvms-4.7.25) 对于 `requires_version_index` 的描述，当不存在依赖项版本信息时，`requires_version_index` 的值为 0。
classpy 目前总是试图在常量池中以 `requires_version_index` 为索引获取版本信息，这导致打开绝大多数 module-info.class 文件时都会产生 NullPointerException，这个 pr 修复了这个问题。