### PR TITLE
Support JDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+import org.gradle.internal.SystemProperties
+import org.gradle.util.VersionNumber
+
+plugins {
+    id 'org.openjfx.javafxplugin' version '0.0.8' apply false
+}
+
 apply plugin: 'java'
 apply plugin: 'application'
 
@@ -23,6 +30,19 @@ task uberjar(type: Jar) {
     with jar
 }
 
+def currentJvm = SystemProperties.getInstance().getJavaVersion()
+
+if (VersionNumber.parse(currentJvm) > VersionNumber.parse("1.8")) {
+    run {
+        doFirst {
+            jvmArgs = [
+                    '--module-path', classpath.asPath,
+                    '--add-modules', 'javafx.controls'
+            ]
+        }
+    }
+}
+
 subprojects {
 
     apply plugin: 'java'
@@ -43,4 +63,8 @@ subprojects {
         jcenter()
     }
 
+}
+
+repositories {
+    mavenCentral()
 }

--- a/classpy-gui/build.gradle
+++ b/classpy-gui/build.gradle
@@ -1,13 +1,18 @@
-// https://openjfx.io/openjfx-docs/#gradle
-// def currentOS = org.gradle.internal.os.OperatingSystem.current()
-// def platform
-// if (currentOS.isWindows()) {
-//     platform = 'win'
-// } else if (currentOS.isLinux()) {
-//     platform = 'linux'
-// } else if (currentOS.isMacOsX()) {
-//     platform = 'mac'
-// }
+import org.gradle.internal.SystemProperties
+import org.gradle.util.VersionNumber
+
+
+def currentJvm = SystemProperties.getInstance().getJavaVersion()
+
+if (VersionNumber.parse(currentJvm) > VersionNumber.parse("1.8")) {
+
+    apply plugin: 'org.openjfx.javafxplugin'
+
+    javafx {
+        version = "11.0.2"
+        modules = [ 'javafx.controls' ]
+    }
+}
 
 dependencies {
     compile project(':classpy-common')
@@ -15,26 +20,4 @@ dependencies {
     compile project(':classpy-binarychunk')
     compile project(':classpy-bitcoin')
     compile project(':classpy-wasm')
-
-    // compile "org.openjfx:javafx-base:11:${platform}"
-    // compile "org.openjfx:javafx-graphics:11:${platform}"
-    // compile "org.openjfx:javafx-controls:11:${platform}"
 }
-
-// compileJava {
-//     doFirst {
-//         options.compilerArgs = [
-//                 '--module-path', classpath.asPath,
-//                 '--add-modules', 'javafx.controls'
-//         ]
-//     }
-// }
-//
-//run {
-//    doFirst {
-//        jvmArgs = [
-//                '--module-path', classpath.asPath,
-//                '--add-modules', 'javafx.controls'
-//        ]
-//    }
-//}


### PR DESCRIPTION
兼容使  gradle 能在 jdk 8 和 jdk 11 下 build & run

原因 jdk 11 之后 移除了 JavaFX 导致jdk 11 运行失败

https://openjfx.io/openjfx-docs/